### PR TITLE
Update item.py to add get_comment option

### DIFF
--- a/build/lib/pyshopee/item.py
+++ b/build/lib/pyshopee/item.py
@@ -343,6 +343,8 @@ class Item(BaseModule):
         @@Significant OpenAPI Updates (2019-06-03)
         """
         return self.client.execute("item/installment/set", "POST", kwargs)
+     def get_comment(self, **kwargs):
+        return self.client.execute("items/comments/get","POST",kwargs)
 
 
 

--- a/build/lib/pyshopee/item.py
+++ b/build/lib/pyshopee/item.py
@@ -343,7 +343,9 @@ class Item(BaseModule):
         @@Significant OpenAPI Updates (2019-06-03)
         """
         return self.client.execute("item/installment/set", "POST", kwargs)
+    
      def get_comment(self, **kwargs):
+            
         return self.client.execute("items/comments/get","POST",kwargs)
 
 


### PR DESCRIPTION
get_comment option have provided in the last shopee API
     def get_comment(self, **kwargs):
        return self.client.execute("items/comments/get","POST",kwargs)